### PR TITLE
Support CloudStack 4.2 error messages on direct calls

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -40,7 +40,12 @@ CloudStackClient.prototype.execute = function (cmd, params, callback) {
                     return callback(err);
                 }
             } else {
-                //Handle CS 4.2 errors as well as old versions
+                //CS 2.2 returns X-Description header
+                if (res.headers['X-Description']) {
+                    return callback(new APIError(res.statusCode, res.headers['X-Description']));
+                }
+
+                //CS 4.2 uses JSON response.
                 if (data) {
                     try {
                         var json = JSON.parse(data);
@@ -54,10 +59,6 @@ CloudStackClient.prototype.execute = function (cmd, params, callback) {
                     catch (e) {
                         console.warn(e.message);
                     }
-                }
-                
-                if (message == '' && res.headers['X-Description']) {
-                    message = res.headers['X-Description'];
                 }
 
                 return callback(new APIError(res.statusCode, message));


### PR DESCRIPTION
CS 4.2 returns data as a JSON response in the body, rather than an X-Description header. It always returns these in the form of cmdnameresponse, where cmdname is the lowercase version of the executed command. For example:

```
{ "registerisoresponse" : {"uuidList":[],"errorcode":431,"cserrorcode":9999,"errortext":"Unsupported scheme for url: ftp://www.example.com/test.iso"} }
```
