### PR TITLE
Fixed polling timeout logic, and error response

### DIFF
--- a/lib/apierror.js
+++ b/lib/apierror.js
@@ -3,7 +3,7 @@
 class APIError extends Error {
 	constructor(code, message) {
 		super();
-		this.name = 'APIError';
+		this.name = 'CloudstackAPIError';
 		this.code = code;
 		this.message = message;
 	}

--- a/lib/cloudstack-client.js
+++ b/lib/cloudstack-client.js
@@ -143,6 +143,7 @@ class CloudStackClient extends EventEmitter {
 					}
 
 					let message = '';
+					let errorcode = 0;
 
 					//CS 4.2 uses JSON response.
 					if (data) {
@@ -151,6 +152,7 @@ class CloudStackClient extends EventEmitter {
 							let respName = cmd.toLowerCase() + 'response';
 
 							if (json[respName] && json[respName].errortext) {
+								errorcode = json[respName].errorcode;
 								message = json[respName].errortext;
 							}
 						}
@@ -159,7 +161,7 @@ class CloudStackClient extends EventEmitter {
 						}
 					}
 
-					return callback(new APIError(res.statusCode, message));
+					return callback(new APIError(errorcode, message));
 				}
 			});
 			res.once('close', (err) => {
@@ -192,19 +194,19 @@ class CloudStackClient extends EventEmitter {
 
 			let jobid = response[Object.keys(response)[0]].jobid;
 			let queryJobResult = (polled) => {
-				this.executeSync('queryAsyncJobResult', { jobid: jobid }, (error, jobresult) => {
+				this.executeSync('queryAsyncJobResult', { jobid: jobid }, (error, queryResponse) => {
 					if (error) {
 						return callback(error);
 					}
 
-					jobresult = jobresult.queryasyncjobresultresponse;
+					queryResponse = queryResponse.queryasyncjobresultresponse;
 
 					// Checking for completion; 0 stands for pending; 1 for successful completion; 2 for error
-					if (jobresult.jobstatus === 1 || jobresult.jobstatus === 2) {
-						if (jobresult.jobstatus === 1) {
-							return callback(null, jobresult);
+					if (queryResponse.jobstatus === 1 || queryResponse.jobstatus === 2) {
+						if (queryResponse.jobstatus === 1) {
+							return callback(null, queryResponse);
 						}
-						return callback(new APIError(jobresult.jobresultcode));
+						return callback(new APIError(queryResponse.jobresult.errorcode, queryResponse.jobresult.errortext));
 					}
 
 					// if polling number is not -1 or undefined, or if polling number is reached, respond with timeout

--- a/lib/cloudstack-client.js
+++ b/lib/cloudstack-client.js
@@ -208,7 +208,7 @@ class CloudStackClient extends EventEmitter {
 					}
 
 					// if polling number is not -1 or undefined, or if polling number is reached, respond with timeout
-					if (this.__pollingNumber !== -1 || !Number.isNaN(this.__pollingNumber) && polled >= this.__pollingNumber) {
+					if (this.__pollingNumber !== -1 && !Number.isNaN(this.__pollingNumber) && polled >= this.__pollingNumber) {
 						return callback(new Error('Timeout'));
 					}
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "csclient",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "description": "An API client for the CloudStack",
   "keywords": [
     "cloudstack",


### PR DESCRIPTION
* The polling timeout logic was checking for not -1 **or** not undefined as pollingNumber for failure which made sure it failed in either case. Changed it so it mustn't fail if pollingNumber is undefined **and** if it's not -1.

* Error response of async job will now include errortext.

* Patch version bump.